### PR TITLE
Set the working directory for the script.

### DIFF
--- a/stats.sh
+++ b/stats.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+#Set the working directory for the script to this one.
+cd "$(dirname "$0")"
+
 precision=2 #how many decimal places 
 units=1000000 #for W/V/A use 1000 for mW/mV/mA
 


### PR DESCRIPTION
It seems bash needs this to set the working directory to the directory that the script is running in. Without it, commands like "`python3 darksky.py`fail because the working directory isn't the one from where the script was run.

https://stackoverflow.com/questions/3349105/how-to-set-current-working-directory-to-the-directory-of-the-script
